### PR TITLE
Several improvements and save_best_n feature

### DIFF
--- a/bin/nmt-coco-metrics
+++ b/bin/nmt-coco-metrics
@@ -17,14 +17,16 @@ from nmtpy.cocoeval.rouge.rouge     import Rouge
 from nmtpy.cocoeval.cider.cider     import Cider
 from nmtpy.cocoeval.meteor.meteor   import Meteor
 
-def print_table(results):
+def print_table(results, sort_by='METEOR'):
     cols = ['Bleu_1', 'Bleu_2', 'Bleu_3', 'Bleu_4',
             'METEOR', 'METEOR (norm)', 'CIDEr', 'ROUGE_L']
     for col in cols:
         print('|{:^15}|'.format(col), end='')
     print()
 
-    for sysname, result in results.items():
+    results = sorted(results.items(), key=lambda x: x[1][sort_by])
+
+    for sysname, result in results:
         if len(results) > 1:
             print(sysname)
         for col in cols:

--- a/bin/nmt-coco-metrics
+++ b/bin/nmt-coco-metrics
@@ -5,6 +5,7 @@
 Computes the BLEU, ROUGE, METEOR, and CIDER
 using the COCO metrics scripts
 """
+import os
 import argparse
 from collections import OrderedDict
 
@@ -16,53 +17,64 @@ from nmtpy.cocoeval.rouge.rouge     import Rouge
 from nmtpy.cocoeval.cider.cider     import Cider
 from nmtpy.cocoeval.meteor.meteor   import Meteor
 
-def load_textfiles(references, hypothesis):
-    # Read hypotheses into hypo dict
-    hypo = {idx: [lines.strip()] for (idx, lines) in enumerate(hypothesis)}
+def print_table(results):
+    cols = ['Bleu_1', 'Bleu_2', 'Bleu_3', 'Bleu_4',
+            'METEOR', 'METEOR (norm)', 'CIDEr', 'ROUGE_L']
+    for col in cols:
+        print('|{:^15}|'.format(col), end='')
+    print()
 
-    # take out newlines before creating dictionary
-    raw_refs = [list(map(str.strip, r)) for r in zip(*references)]
-    refs = {idx: rr for idx, rr in enumerate(raw_refs)}
-
-    # sanity check that we have the same number of references as hypothesis
-    if len(hypo) != len(refs):
-        raise ValueError("There is a sentence number mismatch between the inputs")
-    return refs, hypo
+    for sysname, result in results.items():
+        if len(results) > 1:
+            print(sysname)
+        for col in cols:
+            print('|{:^15,.3f}|'.format(result[col]), end='')
+        print()
 
 if __name__ == '__main__':
-    parser = argparse.ArgumentParser(description="Compute BLEU, METEOR, ROUGE and Cider for single or multiple references.")
+    parser = argparse.ArgumentParser(description="Compute BLEU, METEOR, ROUGE and CIDEr for single or multiple references.")
 
-    parser.add_argument("-w", "--write",    action='store_true',            help='Create a score file containing the results.')
-    parser.add_argument("-l", "--language", default='en',                   help='Sentence language (default: en)')
-    parser.add_argument("hypothesis",       type=argparse.FileType('r'),    help="The hypothesis file")
-    parser.add_argument("references",       type=argparse.FileType('r'),    help="Path to all the reference files", nargs='+')
+    parser.add_argument("-w", "--write",    action='store_true',            help='Create a per-hypothesisscore file containing the results.')
+    parser.add_argument("-l", "--language", default='en',                   help='Hypothesis language (default: en)')
+    parser.add_argument("-s", "--systems",  type=str,                       help="Per-system hypothesis file(s)", nargs='+')
+    parser.add_argument("-r", "--refs",     type=argparse.FileType('r'),    help="Path to all the reference files", nargs='+')
 
     args = parser.parse_args()
-    print("Language: %s" % args.language)
-    print("The number of references is {}".format(len(args.references)))
-    ref, hypo = load_textfiles(args.references, args.hypothesis)
 
     # List of scorers
     scorers = [
         (Bleu(4), ["Bleu_1", "Bleu_2", "Bleu_3", "Bleu_4"]),
         (Meteor(args.language), ["METEOR"]),
-        (Meteor(args.language, norm=True), ["METEOR(norm)"]),
+        (Meteor(args.language, norm=True), ["METEOR (norm)"]),
         (Cider(), ["CIDEr"]),
         (Rouge(), ["ROUGE_L"]),
     ]
 
-    result = OrderedDict()
+    results = OrderedDict()
 
-    for scorer, method in scorers:
-        score, _ = scorer.compute_score(ref, hypo)
-        if score:
-            if not isinstance(score, list):
-                score = [score]
-            for m, s in zip(method, score):
-                result[m] = float('%.4f' % s)
+    # Read multiple reference files
+    raw_refs = [list(map(str.strip, r)) for r in zip(*args.refs)]
+    refs = {idx: rr for idx, rr in enumerate(raw_refs)}
+    
+    # Ranking of multiple systems is possible
+    for hypfile in args.systems:
+        with open(hypfile) as f:
+            # List of hypothesis sentences for this system
+            hypo = {idx: [line.strip()] for (idx, line) in enumerate(f)}
 
-    if args.write:
-        with open("%s.score" % args.hypothesis.name, 'w') as f:
-            f.write("%s\n" % result)
+            result = OrderedDict()
 
-    print(result)
+            for scorer, method in scorers:
+                score, _ = scorer.compute_score(refs, hypo)
+                if score:
+                    if not isinstance(score, list):
+                        score = [score]
+                    for m, s in zip(method, score):
+                        result[m] = float('%.3f' % s)
+
+            if args.write:
+                with open("%s.score" % hypfile, 'w') as f:
+                    f.write("%s\n" % result)
+            results[os.path.basename(hypfile)] = result
+
+    print_table(results)

--- a/bin/nmt-train
+++ b/bin/nmt-train
@@ -220,8 +220,6 @@ if __name__ == '__main__':
     reg_loss = []
     if train_args.decay_c > 0:
         reg_loss.append(model.get_l2_weight_decay(train_args.decay_c))
-    if train_args.alpha_c > 0:
-        reg_loss.append(model.get_alpha_regularizer(train_args.alpha_c))
 
     reg_loss = sum(reg_loss) if len(reg_loss) > 0 else None
 

--- a/bin/nmt-translate
+++ b/bin/nmt-translate
@@ -92,10 +92,6 @@ class Translator(object):
         # for further exporting to json
         self.export = args.export
 
-        # Assume for now that a request for JSON exporting
-        # assumes fetching attentional alphas as well.
-        self.get_att_alphas = self.export
-
         # Fetch other arguments
         self.nbest          = args.nbest
         self.seed           = args.seed
@@ -132,10 +128,6 @@ class Translator(object):
 
             self.models.append(model)
             self.model_options.append(model_options)
-
-        # Sanity check for target vocabularies: they should all be same
-        if self.n_models > 1:
-            assert len(set([len(mopts['trg_dict']) for mopts in self.model_options])) == 1
 
         # Check for post-processing filter
         if "filter" in self.model_options[0]:
@@ -219,7 +211,7 @@ class Translator(object):
         for idx in range(self.n_jobs):
             self.processes[idx] = Process(target=translate_model,
                                           args=(write_queue, read_queue, idx, self.models, self.beam_size,
-                                          self.nbest, self.suppress_unks, self.get_att_alphas,
+                                          self.nbest, self.suppress_unks, self.export,
                                           self.seed, self.mode))
             # Start process and register for cleanup
             self.processes[idx].start()

--- a/bin/nmt-translate
+++ b/bin/nmt-translate
@@ -22,7 +22,6 @@ import numpy as np
 from nmtpy.logger           import Logger
 from nmtpy.metrics          import get_scorer
 from nmtpy.nmtutils         import idx_to_sent
-from nmtpy.textutils        import reduce_to_best
 from nmtpy.sysutils         import *
 from nmtpy.filters          import get_filter
 from nmtpy.iterators.bitext import BiTextIterator
@@ -33,6 +32,14 @@ import nmtpy.cleanup as cleanup
 # Setup the logger
 Logger.setup()
 log = Logger.get()
+
+# This is to avoid thread explosion. Allow
+# each process to use a single thread.
+os.environ["OMP_NUM_THREADS"] = "1"
+os.environ["MKL_NUM_THREADS"] = "1"
+
+# Force CPU
+os.environ["THEANO_FLAGS"] = "device=cpu,optimizer_including=local_remove_all_assert"
 
 """Worker process which does beam search."""
 def translate_model(rqueue, wqueue, pid, models, beam_size, nbest, suppress_unks, get_att_alphas=False, seed=1234, mode="beamsearch"):
@@ -97,7 +104,7 @@ class Translator(object):
         self.seed           = args.seed
         self.mode           = args.decoder
         self.n_jobs         = args.n_jobs
-        self.valid_mode     = args.validmode
+        self.data_mode      = args.validmode
 
         self.models         = []
         self.model_files    = args.models
@@ -166,7 +173,7 @@ class Translator(object):
             # Initialize model's validation data iterator
             # NOTE: data_mode is for best-source-selection decoding for multimodal systems
             if 'data_mode' in inspect.getargspec(self.models[0].load_valid_data).args:
-                self.models[0].load_valid_data(from_translate=True, data_mode=self.valid_mode)
+                self.models[0].load_valid_data(from_translate=True, data_mode=self.data_mode)
             else:
                 self.models[0].load_valid_data(from_translate=True)
 
@@ -300,10 +307,6 @@ class Translator(object):
                     for tr, sc in zip(trs, scs):
                         f.write("%d ||| %s ||| %.6f\n" % (idx, tr, sc))
             else:
-                if self.valid_mode == 'pairs':
-                    # Pick the best hyp out of all source sentences for a single image
-                    self.trans = reduce_to_best(self.trans, self.scores,
-                                                self.iterator.n_unique_images, avoid_unk=True)
                 # Prepare and dump
                 self.hyps = [s[0] for s in self.trans]
                 hyps = "\n".join(self.hyps) + "\n"
@@ -397,14 +400,6 @@ if __name__ == "__main__":
     if args.n_jobs == 0:
         # Auto infer CPU number
         args.n_jobs = (cpu_count() / 2) - 1
-
-    # This is to avoid thread explosion. Allow
-    # each process to use a single thread.
-    os.environ["OMP_NUM_THREADS"] = "1"
-    os.environ["MKL_NUM_THREADS"] = "1"
-
-    # Force CPU
-    os.environ["THEANO_FLAGS"] = "device=cpu,optimizer_including=local_remove_all_assert"
 
     # Print some informations
     log.info("%d CPU processes - beam size = %2d" % (args.n_jobs, args.beam_size))

--- a/bin/nmt-translate
+++ b/bin/nmt-translate
@@ -179,7 +179,6 @@ class Translator(object):
 
             # Set self.iterator to self.models[0].valid_iterator
             self.iterator = self.models[0].valid_iterator
-
             self.n_sentences = self.iterator.n_samples
 
             # Assume validation data encoded in the model
@@ -319,7 +318,6 @@ class Translator(object):
             c = get_scorer(scorer)()
             score = c.compute(self.ref_files, hyp_file)
             results[scorer] = (str(score), score.score)
-        self.results = results
         return results
 
     def dump_json(self, filename):
@@ -428,9 +426,5 @@ if __name__ == "__main__":
     # No need to compute metrics with nbest style files
     if args.decoder != "forced" and args.nbest == 1 \
             and translator.ref_files and not args.score:
-        # Compute all metrics
-        results = translator.compute_metrics(out_file, args.metrics.split(","))
-        # NOTE: This dict is expected from nmt-translate for obtaining the validation results.
-        print(results)
-
-    sys.exit(0)
+        # Compute metrics and print them. Printing is necessary for nmt-train
+        print(translator.compute_metrics(out_file, args.metrics.split(",")))

--- a/bin/nmt-translate
+++ b/bin/nmt-translate
@@ -97,7 +97,6 @@ class Translator(object):
         self.get_att_alphas = self.export
 
         # Fetch other arguments
-        self.first          = args.first
         self.nbest          = args.nbest
         self.seed           = args.seed
         self.mode           = args.decoder
@@ -182,13 +181,7 @@ class Translator(object):
             # Set self.iterator to self.models[0].valid_iterator
             self.iterator = self.models[0].valid_iterator
 
-            # Full or partial decoding given by -f argument
-            if self.first > 0:
-                # Only first self.first sentences
-                self.n_sentences = self.first
-            else:
-                # All sentences
-                self.n_sentences = self.iterator.n_samples
+            self.n_sentences = self.iterator.n_samples
 
             # Assume validation data encoded in the model
             if self.src_files is None:
@@ -385,7 +378,6 @@ class Translator(object):
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(prog='nmt-translate')
-    parser.add_argument('-f', '--first'         , type=int, default=0,      help="How many sentences should be translated, useful for debugging.")
     parser.add_argument('-j', '--n-jobs'        , type=int, default=8,      help="Number of processes (default: 8, 0: Auto)")
     parser.add_argument('-b', '--beam-size'     , type=int, default=12,     help="Beam size (only for beam-search)")
     parser.add_argument('-N', '--nbest'         , type=int, default=1,      help="N for N-best output (only for beam-search)")

--- a/examples/ted-factors/attention_factors-ted-en-fr.conf
+++ b/examples/ted-factors/attention_factors-ted-en-fr.conf
@@ -42,9 +42,6 @@ optimizer: adadelta
 # Learning rate (only for SGD)
 lrate: 1
 
-# 0: no, otherwise alpha regularization factor
-alpha_c: 0.0
-
 # batch size
 batch_size: 80
 

--- a/nmtpy/cocoeval/bleu/bleu_scorer.py
+++ b/nmtpy/cocoeval/bleu/bleu_scorer.py
@@ -258,5 +258,7 @@ class BleuScorer(object):
             print(totalcomps)
             print("ratio:", ratio)
 
+        # Normalize to percentage
+        bleus = [100*b for b in bleus]
         self._score = bleus
         return self._score, bleu_list

--- a/nmtpy/cocoeval/meteor/meteor.py
+++ b/nmtpy/cocoeval/meteor/meteor.py
@@ -53,7 +53,7 @@ class Meteor(object):
             scores.append(score)
 
         # Final score
-        final_score = float(self.meteor_p.stdout.readline().strip())
+        final_score = 100*float(self.meteor_p.stdout.readline().strip())
         self.lock.release()
 
         return final_score, scores

--- a/nmtpy/defaults.py
+++ b/nmtpy/defaults.py
@@ -15,7 +15,6 @@ TRAIN_DEFAULTS = {
         'init':               None,           # Pretrained model .npz file
         'device_id':          'auto',         #
         'seed':               1234,           # RNG seed
-        'alpha_c':            0.,             # Alpha regularization for attentional models (not quite tested)
         'clip_c':             5.,             # Clip gradients above clip_c
         'decay_c':            0.,             # L2 penalty factor
         'patience':           10,             # Early stopping patience

--- a/nmtpy/defaults.py
+++ b/nmtpy/defaults.py
@@ -20,12 +20,13 @@ TRAIN_DEFAULTS = {
         'patience':           10,             # Early stopping patience
         'max_epochs':         100,            # Max number of epochs to train
         'max_iteration':      int(1e6),       # Max number of updates to train
-        'valid_metric':       'bleu',         # bleu, px, meteor
+        'valid_metric':       'bleu',         # one or more metrics separated by comma, 1st one used for early-stopping
         'valid_start':        1,              # Epoch which validation will start
         'valid_njobs':        16,             # # of parallel CPU tasks to do beam-search
         'valid_beam':         12,             # Allow changing beam size during validation
         'valid_freq':         0,              # 0: End of epochs
         'valid_save_hyp':     False,          # Save each output of validation to separate files
         'sample_freq':        0,              # Sampling frequency during training (0: disabled)
-        'save_iter':          False,          # Save each best valid weights to separate files
+        'periodic_save':      0,              # Checkpoint frequency in terms of number of iterations
+        'save_best_n':        4,              # Always keep a set of 4 best validation models on disk
         }

--- a/nmtpy/mainloop.py
+++ b/nmtpy/mainloop.py
@@ -84,7 +84,7 @@ class MainLoop(object):
             cur_score = self.valid_metrics[self.early_metric][-1]
 
             # Custom filename with metric score
-            cur_fname = "%s-val_%s-%.2f.npz" % (self.model.save_path, self.early_metric, cur_score)
+            cur_fname = "%s-val%3.3d-%s_%.3f.npz" % (self.model.save_path, self.vctr, self.early_metric, cur_score)
 
             # Stack is empty, save the model whatsoever
             if len(self.best_models) < self.save_best_n:

--- a/nmtpy/metrics/__init__.py
+++ b/nmtpy/metrics/__init__.py
@@ -4,12 +4,9 @@ from .factors2wordbleu import Factors2word
 
 def get_scorer(scorer):
     scorers = {
-                'meteor': METEORScorer,
-                'bleu'  : MultiBleuScorer,
-		'factors2word': Factors2word,
+                'meteor'      : METEORScorer,
+                'bleu'        : MultiBleuScorer,
+                'factors2word': Factors2word,
               }
 
-    if scorer == 'all':
-        return scorers
-    else:
-        return scorers[scorer]
+    return scorers[scorer]

--- a/nmtpy/metrics/__init__.py
+++ b/nmtpy/metrics/__init__.py
@@ -1,6 +1,19 @@
+import operator
+
 from .bleu   import MultiBleuScorer
 from .meteor import METEORScorer
 from .factors2wordbleu import Factors2word
+
+import numpy as np
+
+comparators = {
+        'bleu'   : (max, operator.gt, 0),
+        'meteor' : (max, operator.gt, 0),
+        'cider'  : (max, operator.gt, 0),
+        'rouge'  : (max, operator.gt, 0),
+        'loss'   : (min, operator.lt, -1),
+        'ter'    : (min, operator.lt, -1),
+    }
 
 def get_scorer(scorer):
     scorers = {
@@ -10,3 +23,25 @@ def get_scorer(scorer):
               }
 
     return scorers[scorer]
+
+def is_last_best(name, history):
+    """Checks whether the last element is the best score so far."""
+    new_value = history[-1]
+    if name in ['bleu', 'meteor', 'cider', 'rouge']:
+        # bigger is better
+        return new_value > max(history[:-1])
+    elif name in ['loss', 'px', 'ter']:
+        # lower is better
+        return new_value < min(history[:-1])
+
+def find_best(name, history):
+    """Returns the best idx and value for the given metric."""
+    history = np.array(history)
+    if name in ['bleu', 'meteor', 'cider', 'rouge']:
+        best_idx = np.argmax(history)
+    elif name in ['loss', 'px', 'ter']:
+        best_idx = np.argmin(history)
+
+    # Validation periods start from 1
+    best_val = history[best_idx]
+    return (best_idx + 1), best_val

--- a/nmtpy/metrics/bleu.py
+++ b/nmtpy/metrics/bleu.py
@@ -2,7 +2,7 @@
 import subprocess
 import pkg_resources
 
-from .metric    import Metric
+from .metric import Metric
 
 BLEU_SCRIPT = pkg_resources.resource_filename('nmtpy', 'external/multi-bleu.perl')
 

--- a/nmtpy/metrics/meteor.py
+++ b/nmtpy/metrics/meteor.py
@@ -13,7 +13,7 @@ class METEORScore(Metric):
         super(METEORScore, self).__init__(score)
         self.name = "METEOR"
         self.score = (100*score) if score else 0.
-        self.score_str = "%.5f" % self.score
+        self.score_str = "%.3f" % self.score
 
 class METEORScorer(object):
     def __init__(self):

--- a/nmtpy/models/attention.py
+++ b/nmtpy/models/attention.py
@@ -439,7 +439,7 @@ class Model(BaseModel):
         embr = embr.reshape([n_timesteps, n_samples, self.embedding_dim])
 
         # encoder
-        proj = get_new_layer(self.enc_type)[1](self.tparams, emb, prefix='encoder', layernorm=self.lnorm)
+        proj  = get_new_layer(self.enc_type)[1](self.tparams, emb, prefix='encoder', layernorm=self.lnorm)
         projr = get_new_layer(self.enc_type)[1](self.tparams, embr, prefix='encoder_r', layernorm=self.lnorm)
 
         # concatenate forward and backward rnn hidden states

--- a/nmtpy/models/attention.py
+++ b/nmtpy/models/attention.py
@@ -261,13 +261,6 @@ class Model(BaseModel):
         self.train_iterator.read()
         self.load_valid_data()
 
-    def add_alpha_regularizer(self, alpha_c):
-        alpha_c = theano.shared(np.float64(alpha_c).astype(FLOAT), name='alpha_c')
-        alpha_reg = alpha_c * (
-            (tensor.cast(self.inputs['y_mask'].sum(0) // self.inputs['x_mask'].sum(0), FLOAT)[:, None] -
-             self.alphas.sum(0))**2).sum(1).mean()
-        return alpha_reg
-
     ###################################################################
     # The following methods can be redefined in child models inheriting
     # from this basic Attention model.

--- a/nmtpy/models/attention_factors.py
+++ b/nmtpy/models/attention_factors.py
@@ -131,7 +131,7 @@ class Model(BaseModel):
         fact_bleu_str, fact_bleu = result['out2']
         self.logger.info("Factors BLEU: %s" % fact_bleu_str)
 
-        return result[metric]
+        return {metric: result[metric]}
 
     @staticmethod
     def beam_search(inputs, f_inits, f_nexts, beam_size=12, maxlen=50, suppress_unks=False, **kwargs):

--- a/nmtpy/models/attention_factors.py
+++ b/nmtpy/models/attention_factors.py
@@ -404,14 +404,7 @@ class Model(BaseModel):
         self.train_iterator.read()
         self.load_valid_data()
 
-    def add_alpha_regularizer(self, alpha_c):
-        alpha_c = theano.shared(np.float64(alpha_c).astype(FLOAT), name='alpha_c')
-        alpha_reg = alpha_c * (
-            (tensor.cast(self.inputs['y_mask'].sum(0) // self.inputs['x_mask'].sum(0), FLOAT)[:, None] -
-             self.alphas.sum(0))**2).sum(1).mean()
-        return alpha_reg
-
-    ###################################################################
+   ###################################################################
     # The following methods can be redefined in child models inheriting
     # from this basic Attention model.
     ###################################################################

--- a/nmtpy/models/basefusion.py
+++ b/nmtpy/models/basefusion.py
@@ -380,8 +380,3 @@ class Model(Attention):
         inputs      = [y, init_state, text_ctx, img_ctx]
         outs        = [next_log_probs, h, alphas]
         self.f_next = theano.function(inputs, outs, name='f_next')
-
-    def get_alpha_regularizer(self, alpha_c):
-        alpha_c = theano.shared(np.float64(alpha_c).astype(FLOAT), name='alpha_c')
-        alpha_reg = alpha_c * ((1.-self.alphas[1].sum(0))**2).sum(0).mean()
-        return alpha_reg

--- a/nmtpy/models/basefusion.py
+++ b/nmtpy/models/basefusion.py
@@ -374,9 +374,6 @@ class Model(Attention):
         # compute the logsoftmax
         next_log_probs = tensor.nnet.logsoftmax(logit)
 
-        # Sample from the softmax distribution
-        # next_probs = tensor.exp(next_log_probs)
-
         ################
         # Build f_next()
         ################

--- a/nmtpy/models/basemodel.py
+++ b/nmtpy/models/basemodel.py
@@ -109,7 +109,7 @@ class BaseModel(object, metaclass=ABCMeta):
         for kk in _from.keys():
             self.tparams[kk].set_value(_from[kk])
 
-    def val_loss(self):
+    def val_loss(self, mean=True):
         """Compute validation loss."""
         probs = []
 
@@ -121,7 +121,10 @@ class BaseModel(object, metaclass=ABCMeta):
             log_probs = self.f_log_probs(*list(data.values())) / norm
             probs.extend(log_probs)
 
-        return np.array(probs).mean()
+        if mean:
+            return np.array(probs).mean()
+        else:
+            return np.array(probs)
 
     def get_l2_weight_decay(self, decay_c, skip_bias=True):
         """Return l2 weight decay regularization term."""

--- a/nmtpy/models/basemodel.py
+++ b/nmtpy/models/basemodel.py
@@ -274,10 +274,6 @@ class BaseModel(object, metaclass=ABCMeta):
         """Reimplement to show model specific information before training."""
         pass
 
-    def get_alpha_regularizer(self, alpha_c):
-        # This should be implemented in attentional models if necessary.
-        return 0.
-
     ##########################################################
     # For all the abstract methods below, you can take a look
     # at attention.py to understand how they are implemented.

--- a/nmtpy/models/basemodel.py
+++ b/nmtpy/models/basemodel.py
@@ -215,7 +215,8 @@ class BaseModel(object, metaclass=ABCMeta):
                                           valid_mode=valid_mode,
                                           f_valid_out=f_valid_out)
 
-        return result[metric]
+        # Return every available metric back
+        return result
 
     def gen_sample(self, input_dict, maxlen=50, argmax=False):
         """Generate samples, do greedy (argmax) decoding or forced decoding."""

--- a/nmtpy/models/dcu_multimodal.py
+++ b/nmtpy/models/dcu_multimodal.py
@@ -286,9 +286,6 @@ class Model(Attention):
         self.valid_iterator.read()
 
     def init_params(self):
-        if self.init_gru_decoder is None:
-            raise Exception('Base fusion model should not be instantiated directly.')
-
         params = OrderedDict()
 
         # embedding weights for encoder (source language)
@@ -589,8 +586,3 @@ class Model(Attention):
         inputs      = [y, init_state, text_ctx, img_ctx]
         outs        = [next_log_probs, h, alphas]
         self.f_next = theano.function(inputs, outs, name='f_next')
-
-    def get_alpha_regularizer(self, alpha_c):
-        alpha_c = theano.shared(np.float64(alpha_c).astype(FLOAT), name='alpha_c')
-        alpha_reg = alpha_c * ((1.-self.alphas[1].sum(0))**2).sum(0).mean()
-        return alpha_reg

--- a/nmtpy/sysutils.py
+++ b/nmtpy/sysutils.py
@@ -231,8 +231,8 @@ def get_exp_identifier(train_args, model_args, suffix=None):
     # Append batch size
     name += '-bs%d' % model_args.batch_size
 
-    # Validation stuff
-    name += '-%s' % train_args.valid_metric
+    # Validation stuff (first: early-stop metric)
+    name += '-%s' % train_args.valid_metric.split(',')[0]
 
     if train_args.valid_freq > 0:
         name += "-each%d" % train_args.valid_freq

--- a/nmtpy/sysutils.py
+++ b/nmtpy/sysutils.py
@@ -253,9 +253,6 @@ def get_exp_identifier(train_args, model_args, suffix=None):
     if train_args.clip_c > 0:
         name += "-gc%d" % int(train_args.clip_c)
 
-    if train_args.alpha_c > 0:
-        name += "-alpha_%.e" % train_args.alpha_c
-
     if isinstance(model_args.weight_init, str):
         name += "-init_%s" % model_args.weight_init
     else:

--- a/nmtpy/sysutils.py
+++ b/nmtpy/sysutils.py
@@ -98,6 +98,13 @@ def real_path(p):
     """Expand UNIX tilde and return real path."""
     return os.path.realpath(os.path.expanduser(p))
 
+def force_symlink(origfile, linkname):
+    try:
+        os.symlink(origfile, linkname)
+    except FileExistsError as e:
+        os.unlink(linkname)
+        os.symlink(origfile, linkname)
+
 def listify(l):
     """Encapsulate l with list[] if not."""
     return [l] if not isinstance(l, list) else l


### PR DESCRIPTION
- Small simplifications to nmt-translate: `-f` no longer exists.
- Multiply BLEU and METEOR of cocoeval by 100 to match percentage
- allow passing `mean=False` to `val_loss` to obtain per sample scores
- Remove alpha_c and alpha regularization stuff that we never used
- Allow passing multiple metrics to `valid_metric` to see them during training. The first one will be used for early-stopping criteria
- Add `save_best_n: <integer>` option to allow keeping N best checkpoints based on early-stop metric on-disk.
- Keep a symlink to the best checkpoint with `.BEST.npz` suffix.
- 